### PR TITLE
Change hugo repo location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - "1.10.x"
 
 install:
-  - go get github.com/spf13/hugo
+  - go get github.com/gohugoio/hugo
 
 script:
   - hugo


### PR DESCRIPTION
As per https://discourse.gohugo.io/t/the-command-go-get-v-github-com-spf13-hugo-failed-and-exited-with-2-during/14601, Hugo now lives at github.com/gohugoio/hugo